### PR TITLE
fix high-iteration stack overflow by flattening the list

### DIFF
--- a/pbkdf2.py
+++ b/pbkdf2.py
@@ -72,7 +72,7 @@ def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
         rv = u = _pseudorandom(salt + _pack_int(block))
         for i in xrange(iterations - 1):
             u = _pseudorandom(''.join(map(chr, u)))
-            rv = starmap(xor, izip(rv, u))
+            rv = list(starmap(xor, izip(rv, u)))
         buf.extend(rv)
     return ''.join(map(chr, buf))[:keylen]
 


### PR DESCRIPTION
The core loop had too many generators: chaining them together results in high stack usage (and reduced speed) when called with a high number of iterations. At roughly 88000 iterations, python segfaults.

Removing those extra stack frames also appears to speed up the loop by about 5%

This fixes #2.
